### PR TITLE
Update for Stardew Valley 1.5.5 beta

### DIFF
--- a/MapTK/FestivalSpots/FestivalSpotsHandler.cs
+++ b/MapTK/FestivalSpots/FestivalSpotsHandler.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using PlatoTK;
 using PlatoTK.Reflection;
-using Harmony;
+using HarmonyLib;
 using StardewValley;
 using System;
 
@@ -24,7 +24,7 @@ namespace MapTK.FestivalSpots
 
         private void GameLoop_GameLaunched(object sender, StardewModdingAPI.Events.GameLaunchedEventArgs e)
         {
-            var harmony = HarmonyInstance.Create("Platonymous.MapTK.FestivalSpots");
+            var harmony = new Harmony("Platonymous.MapTK.FestivalSpots");
 
             Helper.GetPlatoHelper().Events.CalledEventCommand += Events_CalledEventCommand;
 

--- a/MapTK/Locations/LocationsHandler.cs
+++ b/MapTK/Locations/LocationsHandler.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using PlatoTK;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -88,7 +88,7 @@ namespace MapTK.Locations
             var api = Helper.ModRegistry.GetApi<PlatoTK.APIs.IContentPatcher>("Pathoschild.ContentPatcher");
             api.RegisterToken(Helper.ModRegistry.Get(Helper.ModRegistry.ModID).Manifest, "Locations", new LocationsToken());
 
-            HarmonyInstance instance = HarmonyInstance.Create("Platonymous.MapTK.AddLocations");
+            Harmony instance = new Harmony("Platonymous.MapTK.AddLocations");
             instance.Patch(AccessTools.Method(typeof(SaveGame),nameof(SaveGame.loadDataToLocations)), prefix: new HarmonyMethod(typeof(LocationsHandler),nameof(GameLocationsPatch)));
 
             instance.Patch(AccessTools.Method(typeof(NPC), nameof(NPC.populateRoutesFromLocationToLocationList)), prefix: new HarmonyMethod(typeof(LocationsHandler), nameof(SetLocationsBeforeRoutes)));

--- a/MapTK/MapExtras/ExtraLayersHandler.cs
+++ b/MapTK/MapExtras/ExtraLayersHandler.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using xTile.Layers;
 using xTile.ObjectModel;
-using Harmony;
+using HarmonyLib;
 using PlatoTK;
 using TMXTile;
 using Microsoft.Xna.Framework.Graphics;
@@ -37,7 +37,7 @@ namespace MapTK.MapExtras
             helper.Events.GameLoop.DayStarted += InvalidateMerges;
             helper.Events.GameLoop.SaveLoaded += InvalidateMerges;
             helper.Events.GameLoop.SaveCreated += InvalidateMerges;
-            var harmony = HarmonyInstance.Create("Platonymous.MapTK.ExtraLayers");
+            var harmony = new Harmony("Platonymous.MapTK.ExtraLayers");
             harmony.Patch(AccessTools.Method(typeof(GameLocation), "reloadMap"),postfix:new HarmonyMethod(typeof(MapExtrasHandler),nameof(AfterMapReload)));
         }
 
@@ -65,7 +65,7 @@ namespace MapTK.MapExtras
 
         private void SetMapDisplayDevice()
         {
-            HarmonyInstance instance = HarmonyInstance.Create("MatpTK.MapTKDisplayDevice");
+            Harmony instance = new Harmony("MatpTK.MapTKDisplayDevice");
 
             instance.Patch(
                    original: AccessTools.Method(Type.GetType("StardewModdingAPI.Framework.SCore, StardewModdingAPI"), "GetMapDisplayDevice"),

--- a/MapTK/MapTK.csproj
+++ b/MapTK/MapTK.csproj
@@ -4,25 +4,19 @@
     <AssemblyName>MapTK</AssemblyName>
     <RootNamespace>MapTK</RootNamespace>
     <Version>1.2.0</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+
+    <BundleExtraAssemblies>ThirdParty</BundleExtraAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MoonSharp" Version="2.0.0" />
-    <Reference Include="Platonymous.PlatoTK">
-      <HintPath>$(GamePath)\Mods\PlatoTK\PlatoTK.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>false</SpecificVersion>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="TMXTile">
-      <HintPath>$(GamePath)\smapi-internal\TMXTile.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>false</SpecificVersion>
-    </Reference>
+    <Reference Include="Platonymous.PlatoTK" HintPath="$(GamePath)\Mods\PlatoTK\PlatoTK.dll" Private="false" />
+    <Reference Include="TMXTile" HintPath="$(GamePath)\smapi-internal\TMXTile.dll" Private="false" />
   </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />

--- a/MapTK/SpouseRooms/SpouseRoomHandler.cs
+++ b/MapTK/SpouseRooms/SpouseRoomHandler.cs
@@ -8,7 +8,7 @@ using xTile;
 using PlatoTK.Reflection;
 using xTile.Tiles;
 using xTile.Layers;
-using Harmony;
+using HarmonyLib;
 
 namespace MapTK.SpouseRooms
 {
@@ -31,7 +31,7 @@ namespace MapTK.SpouseRooms
             var api = Helper.ModRegistry.GetApi<PlatoTK.APIs.IContentPatcher>("Pathoschild.ContentPatcher");
             api.RegisterToken(Helper.ModRegistry.Get(Helper.ModRegistry.ModID).Manifest, "SpouseRoomX", new SpouseRoomTokenX());
             api.RegisterToken(Helper.ModRegistry.Get(Helper.ModRegistry.ModID).Manifest, "SpouseRoomY", new SpouseRoomTokenY());
-            HarmonyInstance harmony = HarmonyInstance.Create("Platonymous.MapTK.SpouseRooms");
+            Harmony harmony = new Harmony("Platonymous.MapTK.SpouseRooms");
 
             harmony.Patch(
                 AccessTools.Method(typeof(FarmHouse), "loadSpouseRoom"),

--- a/PlatoTK/PlatoTK.csproj
+++ b/PlatoTK/PlatoTK.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>PlatoTK</AssemblyName>
     <RootNamespace>PlatoTK</RootNamespace>
     <Version>1.9.5</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>Platonymous</Authors>
     <Description>Modding Toolkit for Stardew Valley</Description>
     <Copyright>Copyright 2020</Copyright>
@@ -15,8 +15,10 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/Platonymous/PlatoTK/master/LICENSE</PackageLicenseUrl>
     <PackageId>Platonymous.PlatoTK</PackageId>
     <Product>Platonymous.PlatoTK</Product>
-  </PropertyGroup>  
-  
+
+    <BundleExtraAssemblies>ThirdParty</BundleExtraAssemblies>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="MoonSharp" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
@@ -24,21 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
-  <Reference Include="BmFont">
-    <HintPath>$(GamePath)\BmFont.dll</HintPath>
-    <Private>true</Private>
-    <SpecificVersion>false</SpecificVersion>
-  </Reference>
-    <Reference Include="TMXTile">
-      <HintPath>$(GamePath)\smapi-internal\TMXTile.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>false</SpecificVersion>
-    </Reference>
-</ItemGroup>
+    <Reference Include="BmFont" HintPath="$(GamePath)\BmFont.dll" Private="false" />
+    <Reference Include="TMXTile" HintPath="$(GamePath)\smapi-internal\TMXTile.dll" Private="false" />
+  </ItemGroup>
 
   <Import Project="$(SolutionDir)\common.targets" />
 
-  <ItemGroup>
-    <PackageReference Update="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
-  </ItemGroup>
 </Project>

--- a/common.targets
+++ b/common.targets
@@ -105,7 +105,7 @@
   </Target>
   -->
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.2.2" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0-beta.20210916" />
   </ItemGroup>
   
 


### PR DESCRIPTION
This pull request updates the code for compatibility with the Stardew Valley 1.5.5 beta.

More specifically, this PR...

* updates the target frameworks (the game uses .NET 5 now);
* updates to Harmony 2.1 (needed for .NET 5);
* updates the mod build package;
* updates how the mods bundle extra dependencies for .NET 5.