### PR TITLE
Update for SMAPI 3.14.0

### DIFF
--- a/MapTK/FestivalSpots/FestivalSpotsHandler.cs
+++ b/MapTK/FestivalSpots/FestivalSpotsHandler.cs
@@ -36,7 +36,7 @@ namespace MapTK.FestivalSpots
         {
             if(e.Trigger.ToLower() == "loadactors")
             {
-                Dictionary<string, FestivalNPCData> npcData = Helper.Content.Load<Dictionary<string, FestivalNPCData>>(FestivalPlacementDataAsset, ContentSource.GameContent);
+                Dictionary<string, FestivalNPCData> npcData = Helper.GameContent.Load<Dictionary<string, FestivalNPCData>>(FestivalPlacementDataAsset);
 
                 npcData.Keys
                     .ToList()

--- a/MapTK/Locations/LocationsHandler.cs
+++ b/MapTK/Locations/LocationsHandler.cs
@@ -96,8 +96,8 @@ namespace MapTK.Locations
 
         internal static void SetLocationsBeforeRoutes()
         {
-            Helper.Content.InvalidateCache(LocationsDictionary);
-            var locations = Helper.Content.Load<Dictionary<string, LocationData>>(LocationsDictionary, ContentSource.GameContent);
+            Helper.GameContent.InvalidateCache(LocationsDictionary);
+            var locations = Helper.GameContent.Load<Dictionary<string, LocationData>>(LocationsDictionary);
             var result = new List<GameLocation>();
             locations.Values
                 .Where(l => !Game1.locations.Any(g => g.Name == l.Name))
@@ -119,8 +119,8 @@ namespace MapTK.Locations
 
         private static List<GameLocation> InitializeNewLocations()
         {
-            Helper.Content.InvalidateCache(LocationsDictionary);
-            var locations = Helper.Content.Load<Dictionary<string, LocationData>>(LocationsDictionary, ContentSource.GameContent);
+            Helper.GameContent.InvalidateCache(LocationsDictionary);
+            var locations = Helper.GameContent.Load<Dictionary<string, LocationData>>(LocationsDictionary);
             var result = new List<GameLocation>();
             locations.Values
                 .Where(l => !Game1.locations.Any(g => g.Name == l.Name) || l.Save)
@@ -223,8 +223,8 @@ namespace MapTK.Locations
         {
             locationStore.Clear();
             var locationDataStore = new LocationSaveData();
-            var locations = Helper.Content.Load<Dictionary<string, LocationData>>(LocationsDictionary, ContentSource.GameContent);
-            Helper.Content.Load<Dictionary<string, LocationData>>(LocationsDictionary, ContentSource.GameContent)
+            var locations = Helper.GameContent.Load<Dictionary<string, LocationData>>(LocationsDictionary);
+            Helper.GameContent.Load<Dictionary<string, LocationData>>(LocationsDictionary)
                 .Where(l => l.Value.Save && Game1.getLocationFromName(l.Value.Name) is GameLocation)
                 .Select(l => Game1.getLocationFromName(l.Value.Name))
                 .ToList()

--- a/MapTK/MapExtras/ExtraLayersHandler.cs
+++ b/MapTK/MapExtras/ExtraLayersHandler.cs
@@ -43,10 +43,10 @@ namespace MapTK.MapExtras
 
         private void InvalidateMerges(object sender, EventArgs e)
         {
-            Plato.ModHelper.Content.InvalidateCache(MapMergeDirectory);
-            MapMergerIAssetEditor.MapMergeDataSet = Plato.ModHelper.Content.Load<Dictionary<string, MapMergeData>>(MapMergeDirectory, ContentSource.GameContent);
-            var mm = Plato.ModHelper.Content.Load<Dictionary<string, MapMergeData>>(MapMergeDirectory, ContentSource.GameContent);
-            mm.Select(s => s.Value).ToList().ForEach(m => Plato.ModHelper.Content.InvalidateCache(m.Target));
+            Plato.ModHelper.GameContent.InvalidateCache(MapMergeDirectory);
+            MapMergerIAssetEditor.MapMergeDataSet = Plato.ModHelper.GameContent.Load<Dictionary<string, MapMergeData>>(MapMergeDirectory);
+            var mm = Plato.ModHelper.GameContent.Load<Dictionary<string, MapMergeData>>(MapMergeDirectory);
+            mm.Select(s => s.Value).ToList().ForEach(m => Plato.ModHelper.GameContent.InvalidateCache(m.Target));
         }
 
         private void GameLoop_GameLaunched(object sender, GameLaunchedEventArgs e)

--- a/MapTK/MapExtras/GameAssetLoader.cs
+++ b/MapTK/MapExtras/GameAssetLoader.cs
@@ -25,9 +25,9 @@ namespace MapTK.MapExtras
             string[] path = asset.AssetName.Split(new[] { Path.DirectorySeparatorChar, '/', '\\' });
 
             if (path[0] == "GameContent")
-                return (T)(object)helper.Content.Load<Texture>(string.Join(Path.DirectorySeparatorChar.ToString(), path.Skip(1)), ContentSource.GameContent);
+                return (T)(object)helper.GameContent.Load<Texture>(string.Join(Path.DirectorySeparatorChar.ToString(), path.Skip(1)));
             else
-                return (T)(object)helper.Content.Load<Texture>(string.Join(Path.DirectorySeparatorChar.ToString(), path.Skip(2)), ContentSource.GameContent);
+                return (T)(object)helper.GameContent.Load<Texture>(string.Join(Path.DirectorySeparatorChar.ToString(), path.Skip(2)));
         }
     }
 }

--- a/MapTK/MapExtras/IntegratedMapEditsAssetEditor.cs
+++ b/MapTK/MapExtras/IntegratedMapEditsAssetEditor.cs
@@ -6,6 +6,7 @@ using StardewValley;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using StardewModdingAPI.Events;
 using xTile;
 using xTile.Layers;
 using xTile.ObjectModel;
@@ -13,7 +14,7 @@ using xTile.Tiles;
 
 namespace MapTK.MapExtras
 {
-    internal class IntegratedMapEditsAssetEditor : IAssetEditor
+    internal class IntegratedMapEditsAssetEditor
     {
         private readonly IPlatoHelper Plato;
         internal const string UseOrderProperty = "@As_Order";
@@ -22,12 +23,13 @@ namespace MapTK.MapExtras
             Plato = helper.GetPlatoHelper();
         }
 
-        public bool CanEdit<T>(IAssetInfo asset)
+        public void OnAssetRequested(AssetRequestedEventArgs e)
         {
-            return asset.DataType == typeof(Map);
+            if (e.DataType == typeof(Map))
+                e.Edit(this.Edit);
         }
 
-        public void Edit<T>(IAssetData asset)
+        private void Edit(IAssetData asset)
         {
             var mapAsset = asset.AsMap();
             var map = mapAsset.Data;

--- a/MapTK/MapExtras/IntegratedMapMergesHandler.cs
+++ b/MapTK/MapExtras/IntegratedMapMergesHandler.cs
@@ -1,18 +1,21 @@
 ﻿using StardewModdingAPI;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using StardewModdingAPI.Events;
 
 namespace MapTK.MapExtras
 {
     internal class IntegratedMapMergesHandler
     {
+        private readonly IntegratedMapEditsAssetEditor AssetEditor;
 
         public IntegratedMapMergesHandler(IModHelper helper)
         {
-            helper.Content.AssetEditors.Add(new IntegratedMapEditsAssetEditor(helper));
+            this.AssetEditor = new IntegratedMapEditsAssetEditor(helper);
+            helper.Events.Content.AssetRequested += OnAssetRequested;
+        }
+
+        public void OnAssetRequested(object sender, AssetRequestedEventArgs e)
+        {
+            this.AssetEditor.OnAssetRequested(e);
         }
     }
 }

--- a/MapTK/MapExtras/MapMergerIAssetEditor.cs
+++ b/MapTK/MapExtras/MapMergerIAssetEditor.cs
@@ -35,7 +35,7 @@ namespace MapTK.MapExtras
         {
             if (asset.DataType == typeof(Map)
                 && GetMapMerges().FirstOrDefault(m => asset.AssetNameEquals(m.Target)) is MapMergeData merge
-                && Plato.ModHelper.Content.Load<Map>(merge.Source, ContentSource.GameContent) is Map patch) {
+                && Plato.ModHelper.GameContent.Load<Map>(merge.Source) is Map patch) {
                 Map patched = Plato.Content.Maps.PatchMapArea(asset.AsMap().Data, patch, new Point(merge.ToArea.X,merge.ToArea.Y), merge.FromArea, merge.PatchMapProperties,merge.RemoveEmpty);
                 asset.AsMap().PatchMap(patched, merge.ToArea, merge.ToArea);
 

--- a/MapTK/MapExtras/MapMergerIAssetEditor.cs
+++ b/MapTK/MapExtras/MapMergerIAssetEditor.cs
@@ -1,17 +1,15 @@
 ﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using PlatoTK;
 using StardewModdingAPI;
-using StardewValley;
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using StardewModdingAPI.Events;
 using xTile;
 using xTile.ObjectModel;
 
 namespace MapTK.MapExtras
 {
-    internal class MapMergerIAssetEditor : IAssetEditor, IAssetLoader
+    internal class MapMergerIAssetEditor
     {
         internal readonly IPlatoHelper Plato;
         internal static Dictionary<string, MapMergeData> MapMergeDataSet = new Dictionary<string, MapMergeData>();
@@ -26,33 +24,27 @@ namespace MapTK.MapExtras
             return MapMergeDataSet.Select(k => k.Value);
         }
 
-        public bool CanEdit<T>(IAssetInfo asset)
+        public void OnAssetRequested(AssetRequestedEventArgs e)
         {
-            return GetMapMerges().Any(m => asset.AssetNameEquals(m.Target));
-        }
-
-        public void Edit<T>(IAssetData asset)
-        {
-            if (asset.DataType == typeof(Map)
-                && GetMapMerges().FirstOrDefault(m => asset.AssetNameEquals(m.Target)) is MapMergeData merge
+            if (e.DataType == typeof(Map)
+                && GetMapMerges().FirstOrDefault(m => e.NameWithoutLocale.IsEquivalentTo(m.Target)) is MapMergeData merge
                 && Plato.ModHelper.GameContent.Load<Map>(merge.Source) is Map patch) {
-                Map patched = Plato.Content.Maps.PatchMapArea(asset.AsMap().Data, patch, new Point(merge.ToArea.X,merge.ToArea.Y), merge.FromArea, merge.PatchMapProperties,merge.RemoveEmpty);
-                asset.AsMap().PatchMap(patched, merge.ToArea, merge.ToArea);
+                e.Edit(asset =>
+                {
+                    var editor = asset.AsMap();
 
-                if (merge.PatchMapProperties)
-                    foreach (KeyValuePair<string, PropertyValue> p in patched.Properties)
-                        asset.AsMap().Data.Properties[p.Key] = p.Value;
+                    Map patched = Plato.Content.Maps.PatchMapArea(editor.Data, patch, new Point(merge.ToArea.X, merge.ToArea.Y), merge.FromArea, merge.PatchMapProperties, merge.RemoveEmpty);
+                    editor.PatchMap(patched, merge.ToArea, merge.ToArea);
+
+                    if (merge.PatchMapProperties)
+                    {
+                        foreach (KeyValuePair<string, PropertyValue> p in patched.Properties)
+                            editor.Data.Properties[p.Key] = p.Value;
+                    }
+                });
             }
-        }
-
-        public bool CanLoad<T>(IAssetInfo asset)
-        {
-           return asset.AssetNameEquals(MapExtrasHandler.MapMergeDirectory);
-        }
-
-        public T Load<T>(IAssetInfo asset)
-        {
-            return (T)(object)MapMergeDataSet;
+            else if (e.Name.IsEquivalentTo(MapExtrasHandler.MapMergeDirectory))
+                e.LoadFrom(() => MapMergeDataSet, AssetLoadPriority.Medium);
         }
     }
 }

--- a/MapTK/MapTKMod.cs
+++ b/MapTK/MapTKMod.cs
@@ -5,11 +5,14 @@ using MapTK.MapExtras;
 using MapTK.FestivalSpots;
 using System.Collections.Generic;
 using MapTK.TileActions;
+using StardewModdingAPI.Events;
 
 namespace MapTK
 {
     public class MapTKMod : Mod
     {
+        private GameAssetLoader GameAssetLoader;
+
         internal static LocationsHandler LocationsHandler;
         internal static MapExtrasHandler MapExtrasHandler;
         internal static SpouseRoomHandler SpouseRoomHandler;
@@ -20,12 +23,18 @@ namespace MapTK
         public override void Entry(IModHelper helper)
         {
             helper.Events.GameLoop.GameLaunched += SetCompatOptions;
+            helper.Events.Content.AssetRequested += OnAssetRequested;
+            GameAssetLoader = new GameAssetLoader(helper);
             LocationsHandler = new LocationsHandler(helper);
             MapExtrasHandler = new MapExtrasHandler(helper);
             SpouseRoomHandler = new SpouseRoomHandler(helper);
             FestivalSpotsHandler = new FestivalSpotsHandler(helper);
             TileActionsHandler = new TileActionsHandler(helper);
-            helper.Content.AssetLoaders.Add(new GameAssetLoader(helper));
+        }
+
+        private void OnAssetRequested(object sender, AssetRequestedEventArgs e)
+        {
+            GameAssetLoader.OnAssetRequested(e);
         }
 
         private void SetCompatOptions(object sender, StardewModdingAPI.Events.GameLaunchedEventArgs e)

--- a/MapTK/SpouseRooms/SpouseRoomHandler.cs
+++ b/MapTK/SpouseRooms/SpouseRoomHandler.cs
@@ -1,5 +1,4 @@
 ﻿using StardewModdingAPI;
-using StardewValley;
 using StardewValley.Locations;
 using System;
 using System.Drawing;
@@ -55,7 +54,7 @@ namespace MapTK.SpouseRooms
                 rectangle = new Microsoft.Xna.Framework.Rectangle(pos[0], pos[1], 6, 9);
             }
 
-            Map spouseRoomMap = Helper.Content.Load<Map>(VanillaSpouseRoomMap, ContentSource.GameContent);
+            Map spouseRoomMap = Helper.GameContent.Load<Map>(VanillaSpouseRoomMap);
 
             int spot = GetIndexForSpouse(spouse);
             bool isVanilla = spot == -1;

--- a/MapTK/TileActions/MapTKInventory.cs
+++ b/MapTK/TileActions/MapTKInventory.cs
@@ -22,7 +22,7 @@ namespace MapTK.TileActions
 
         private static Dictionary<ISalable, int[]> GetPriceAndStock(string shop, string id, IModHelper helper)
         {
-            if (helper.Content.Load<Dictionary<string, MapTKInventory>>(InventoryDataAsset, ContentSource.GameContent).TryGetValue(id, out MapTKInventory inv))
+            if (helper.GameContent.Load<Dictionary<string, MapTKInventory>>(InventoryDataAsset).TryGetValue(id, out MapTKInventory inv))
             {
                 Dictionary<ISalable, int[]> priceAndStock = new Dictionary<ISalable, int[]>();
 

--- a/MapTK/TileActions/MapTKShop.cs
+++ b/MapTK/TileActions/MapTKShop.cs
@@ -48,7 +48,7 @@ namespace MapTK.TileActions
 
         internal static MapTKShop GetShop(IModHelper helper, string id)
         {
-            var dict = helper.Content.Load<Dictionary<string, MapTKShop>>(ShopDataAsset, ContentSource.GameContent);
+            var dict = helper.GameContent.Load<Dictionary<string, MapTKShop>>(ShopDataAsset);
 
             if(dict.TryGetValue(id, out MapTKShop shop))
                 return shop;

--- a/MapTK/TileActions/TileActionsHandler.cs
+++ b/MapTK/TileActions/TileActionsHandler.cs
@@ -133,7 +133,7 @@ namespace MapTK.TileActions
                         }
                         else
                         {
-                            var npc = new NPC(null, Vector2.Zero, "Town", 0, shop.ShopKeeper.Split('.')[0], false, null, Plato.ModHelper.Content.Load<Texture2D>(Path.Combine(ShopPortraitsToken.ShopPortraitsPrefix,shop.ShopKeeper), ContentSource.GameContent));
+                            var npc = new NPC(null, Vector2.Zero, "Town", 0, shop.ShopKeeper.Split('.')[0], false, null, Plato.ModHelper.GameContent.Load<Texture2D>($"{ShopPortraitsToken.ShopPortraitsPrefix}/{shop.ShopKeeper}"));
                             shopMenu.portraitPerson = npc;
                             Game1.removeThisCharacterFromAllLocations(npc);
                         }
@@ -247,7 +247,7 @@ namespace MapTK.TileActions
             }
             else
             {
-                code = Plato.ModHelper.Content.Load<Dictionary<string, string>>(LuaScriptRepository, ContentSource.GameContent)[codeId];
+                code = Plato.ModHelper.GameContent.Load<Dictionary<string, string>>(LuaScriptRepository)[codeId];
                 if (parameter.Length > 1)
                     function = parameter[1];
             }

--- a/MapTK/manifest.json
+++ b/MapTK/manifest.json
@@ -5,7 +5,7 @@
   "Description": "Map Toolkit",
   "UniqueID": "Platonymous.MapTK",
   "EntryDll": "MapTK.dll",
-  "MinimumApiVersion": "2.11",
+  "MinimumApiVersion": "3.14.0",
   "UpdateKeys": [ "Nexus:" ],
   "Dependencies": [
     {

--- a/PlatoTK/Content/AssetInjection.cs
+++ b/PlatoTK/Content/AssetInjection.cs
@@ -35,7 +35,7 @@ namespace PlatoTK.Content
             if (MatchesConditions != newValue)
             {
                 MatchesConditions = newValue;
-                Helper.ModHelper.Content.InvalidateCache(AssetName);
+                Helper.ModHelper.GameContent.InvalidateCache(AssetName);
             }
         }
 

--- a/PlatoTK/Presets/ArcadeMachinePreset.cs
+++ b/PlatoTK/Presets/ArcadeMachinePreset.cs
@@ -57,7 +57,7 @@ namespace PlatoTK.Presets
 
             if (helper.ModHelper.ModRegistry.GetApi<IMobilePhoneApi>("aedenthorn.MobilePhone") is IMobilePhoneApi phone)
             {
-                    Texture2D appIcon = helper.ModHelper.Content.Load<Texture2D>(specs.Icon, StardewModdingAPI.ContentSource.GameContent);
+                    Texture2D appIcon = helper.ModHelper.GameContent.Load<Texture2D>(specs.Icon);
                     bool success = phone.AddApp(specs.Id, specs.Name, () =>
                     {
                         specs.Start();

--- a/PlatoTK/UI/Components/Wrapper.cs
+++ b/PlatoTK/UI/Components/Wrapper.cs
@@ -99,7 +99,9 @@ namespace PlatoTK.UI.Components
                 if (content)
                     value = value.Substring("content>".Length);
 
-                texture = Helper.ModHelper.Content.Load<Texture2D>(value, content ? StardewModdingAPI.ContentSource.GameContent : StardewModdingAPI.ContentSource.ModFolder);
+                texture = content
+                    ? Helper.ModHelper.GameContent.Load<Texture2D>(value)
+                    : Helper.ModHelper.ModContent.Load<Texture2D>(value);
             }
 
             return texture is Texture;

--- a/PlatoTK/UI/UIHelper.cs
+++ b/PlatoTK/UI/UIHelper.cs
@@ -107,7 +107,7 @@ namespace PlatoTK.UI
         public List<Texture2D> LoadFontPages(FontFile fontFile, string assetName)
         {
             //return fontFile.Pages.Select(p => Plato.ModHelper.Content.Load<Texture2D>(p.File,StardewModdingAPI.ContentSource.GameContent)).ToList();
-            return fontFile.Pages.Select(p => Plato.ModHelper.Content.Load<Texture2D>(Path.Combine(Path.GetDirectoryName(assetName), p.File))).ToList();
+            return fontFile.Pages.Select(p => Plato.ModHelper.ModContent.Load<Texture2D>($"{Path.GetDirectoryName(assetName)}/{p.File}")).ToList();
         }
 
         public FontFile LoadFontFile(string assetName)
@@ -124,8 +124,8 @@ namespace PlatoTK.UI
         public SpriteFont LoadSpriteFont(string assetName)
         {
             //return Plato.ModHelper.Content.Load<SpriteFont>(assetName);
-            Texture2D texture = Plato.ModHelper.Content.Load<Texture2D>(Path.Combine(Path.GetDirectoryName(assetName), Path.GetFileNameWithoutExtension(assetName) + ".png"));
-            SpriteFontData data = Plato.ModHelper.Content.Load<SpriteFontData>(assetName);
+            Texture2D texture = Plato.ModHelper.ModContent.Load<Texture2D>($"{Path.GetDirectoryName(assetName)}/{Path.GetFileNameWithoutExtension(assetName)}.png");
+            SpriteFontData data = Plato.ModHelper.ModContent.Load<SpriteFontData>(assetName);
             object[] parameter = new object[]{
                     texture,
                     data.Glyphs.Values

--- a/PlatoTK/Utils/BasicUtils.cs
+++ b/PlatoTK/Utils/BasicUtils.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Xna.Framework;
-using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Objects;
 using StardewValley.Tools;
@@ -52,7 +51,7 @@ namespace PlatoTK.Utils
         public void ReloadMap(GameLocation location)
         {
             GameLocation l = (location ?? Game1.currentLocation);
-            Plato.ModHelper.Content.InvalidateCache(l.mapPath.Value);
+            Plato.ModHelper.GameContent.InvalidateCache(l.mapPath.Value);
             l?.reloadMap();
             l?.resetForPlayerEntry();
         }
@@ -176,28 +175,28 @@ namespace PlatoTK.Utils
                 if (index != -1)
                     item = new Hat(index);
                 else if (name != "none")
-                    item = new Hat(GetIndexByName(Plato.ModHelper.Content.Load<Dictionary<int, string>>(@"Data/hats", ContentSource.GameContent), name));
+                    item = new Hat(GetIndexByName(Plato.ModHelper.GameContent.Load<Dictionary<int, string>>(@"Data/hats"), name));
             }
             else if (type == "Boots")
             {
                 if (index != -1)
                     item = new Boots(index);
                 else if (name != "none")
-                    item = new Boots(GetIndexByName(Plato.ModHelper.Content.Load<Dictionary<int, string>>(@"Data/Boots", ContentSource.GameContent), name));
+                    item = new Boots(GetIndexByName(Plato.ModHelper.GameContent.Load<Dictionary<int, string>>(@"Data/Boots"), name));
             }
             else if (type == "Clothing")
             {
                 if (index != -1)
                     item = new Clothing(index);
                 else if (name != "none")
-                    item = new Clothing(GetIndexByName(Plato.ModHelper.Content.Load<Dictionary<int, string>>(@"Data/ClothingInformation", ContentSource.GameContent), name));
+                    item = new Clothing(GetIndexByName(Plato.ModHelper.GameContent.Load<Dictionary<int, string>>(@"Data/ClothingInformation"), name));
             }
             else if (type == "TV")
             {
                 if (index != -1)
                     item = new StardewValley.Objects.TV(index, Vector2.Zero);
                 else if (name != "none")
-                    item = new TV(GetIndexByName(Plato.ModHelper.Content.Load<Dictionary<int, string>>(@"Data/Furniture", ContentSource.GameContent), name), Vector2.Zero);
+                    item = new TV(GetIndexByName(Plato.ModHelper.GameContent.Load<Dictionary<int, string>>(@"Data/Furniture"), name), Vector2.Zero);
             }
             else if (type == "IndoorPot")
                 item = new StardewValley.Objects.IndoorPot(Vector2.Zero);
@@ -214,7 +213,7 @@ namespace PlatoTK.Utils
                 if (index != -1)
                     item = new StardewValley.Objects.Furniture(index, Vector2.Zero);
                 else if (name != "none")
-                    item = new Furniture(GetIndexByName(Plato.ModHelper.Content.Load<Dictionary<int, string>>(@"Data/Furniture", ContentSource.GameContent), name), Vector2.Zero);
+                    item = new Furniture(GetIndexByName(Plato.ModHelper.GameContent.Load<Dictionary<int, string>>(@"Data/Furniture"), name), Vector2.Zero);
             }
             else if (type == "Sign")
                 item = new StardewValley.Objects.Sign(Vector2.Zero, index);
@@ -227,7 +226,7 @@ namespace PlatoTK.Utils
                 if (index != -1)
                     item = new MeleeWeapon(index);
                 else if (name != "none")
-                    item = new MeleeWeapon(GetIndexByName(Plato.ModHelper.Content.Load<Dictionary<int, string>>(@"Data/weapons", ContentSource.GameContent), name));
+                    item = new MeleeWeapon(GetIndexByName(Plato.ModHelper.GameContent.Load<Dictionary<int, string>>(@"Data/weapons"), name));
 
             }
             else if (type == "SDVType")

--- a/PlatoTK/manifest.json
+++ b/PlatoTK/manifest.json
@@ -5,7 +5,7 @@
   "Description": "Modding Toolkit",
   "UniqueID": "Platonymous.PlatoTK",
   "EntryDll": "PlatoTK.dll",
-  "MinimumApiVersion": "3.2.0",
+  "MinimumApiVersion": "3.14.0",
   "UpdateKeys": [ "Nexus:6589" ],
   "Dependencies": [
     {

--- a/common.targets
+++ b/common.targets
@@ -105,7 +105,7 @@
   </Target>
   -->
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0-beta.20210916" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.1" />
   </ItemGroup>
   
 


### PR DESCRIPTION
This updates the code for SMAPI 3.14 and the upcoming SMAPI 4.0.

More specifically, this...
* migrates to the new [content interception](https://stardewvalleywiki.com/Modding:Migrate_to_SMAPI_4.0#Content_interception_API) and [content load](https://stardewvalleywiki.com/Modding:Migrate_to_SMAPI_4.0#Content_loading_API) APIs;
* updates the min SMAPI version in `manifest.json`;
* updates the mod build package.
